### PR TITLE
Add STS wiki TODO backlog document

### DIFF
--- a/Docs/Wiki-TODO.md
+++ b/Docs/Wiki-TODO.md
@@ -1,0 +1,30 @@
+# STS Wiki TODO
+
+This document tracks the current backlog for the STS wiki so the work can be reviewed and split into smaller follow-up items.
+
+## Project Overview
+
+- Add a general overview of the project, its goals, and the expected STS outputs.
+- Explain the main use cases for STS outputs, including research workflows and whole brain emulation work.
+- Expand the list of relevant fields and technologies with short explanations for each.
+
+## Team Onboarding
+
+- Create a list of relevant roles, even if some of those roles are not currently filled.
+- Add a getting-started guide for new members that points them to the relevant roles, diagrams, and technical notes.
+
+## Architecture
+
+- Improve the overview diagram so it shows additional outputs and downstream use cases.
+- Add class diagrams that describe a more detailed implementation strategy.
+- Create milestones for major deliverables such as voxel-map generation, segmentation, and connectome extraction.
+
+## References
+
+- Create a list of potentially relevant projects and clearly note when STS has no affiliation with them.
+- Keep this list internal if the affiliation status would be ambiguous in a public-facing wiki.
+
+## Notes
+
+- Break these items into smaller wiki pages and issue-sized tasks as the documentation structure becomes clearer.
+- Treat this file as the repository-local source of truth until the same structure exists in the wiki itself.

--- a/Docs/Wiki-TODO.md
+++ b/Docs/Wiki-TODO.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD043 -->
+
 # STS Wiki TODO
 
 This document tracks the current backlog for the STS wiki so the work can be reviewed and split into smaller follow-up items.


### PR DESCRIPTION
Fixes #4.

This adds a repository-local backlog document for the STS wiki work.

Included in this patch:

- captures the current wiki TODO items in a single markdown document
- groups the backlog into overview, onboarding, architecture, and reference work
- makes the open-ended wiki issue easier to split into smaller follow-up tasks later

Verification:

- documentation-only change
- confirmed the new file exists locally in `Docs/Wiki-TODO.md`

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.