### PR TITLE
Implement sandbox data loader API

### DIFF
--- a/Sandbox/LoadNeuronData/DataLoader.py
+++ b/Sandbox/LoadNeuronData/DataLoader.py
@@ -29,7 +29,7 @@ class LayerRecord:
     tiles: Tuple[Path, ...]
 
 
-class DataLoader:
+class DataLoader:  # noqa: D203,D213
     """Load sequential FlyEM layers and tiles from a directory tree.
 
     The loader scans the dataset once per root path and caches the discovered
@@ -73,7 +73,7 @@ class DataLoader:
         tiles: RangeSpec = None,
         *,
         load_images: bool = True,
-    ) -> Dict[int, List[ImageValue]]:
+    ) -> Dict[int, List[ImageValue]]:  # noqa: D213
         """Return a sequential layer->tiles dictionary.
 
         `layers` may be:

--- a/Sandbox/LoadNeuronData/DataLoader.py
+++ b/Sandbox/LoadNeuronData/DataLoader.py
@@ -1,47 +1,212 @@
 #!/usr/bin/env python3
 
-import os
-from tqdm import tqdm
-import numpy as np
-import magic
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - optional runtime dependency
+    np = None
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - optional runtime dependency
+    Image = None
 
 
-# TODO: We should be able to scan the dataset/database and put the ID structure into memory.
-#       We should be able to load individual images by ID (ID will be the layer number and image number within the layer)
+RangeSpec = Optional[Union[int, Sequence[int]]]
+ImageValue = Union["np.ndarray", Path]
+
+
+@dataclass(frozen=True)
+class LayerRecord:
+    identifier: int
+    path: Path
+    tiles: Tuple[Path, ...]
 
 
 class DataLoader:
-    def __init__(self, root) -> None:
-        self.root = root
+    """Load sequential FlyEM layers and tiles from a directory tree.
 
-    def load():
-        layers = [[]]
-        with tqdm(os.walk(root)) as progress:
-            for path, dirs, files in progress:
-                layer = []
-                
-                for file in files:
-                    file_path = path+'/'+file
+    The loader scans the dataset once per root path and caches the discovered
+    layer/tile structure at the class level so repeated instances do not need
+    to rescan the dataset.
+    """
 
-                    if magic.from_file(file_path, mime=True) == "image/jpeg":
-                        layer.append(file_path)
-                        image = np.asarray(Image.open(file_path))
+    IMAGE_SUFFIXES: ClassVar[Tuple[str, ...]] = (".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp")
+    _DATASET_CACHE: ClassVar[Dict[Path, Tuple[LayerRecord, ...]]] = {}
 
-                        num_images += 1
-                        if image.sum() == 0:
-                            num_empty += 1
-                    
-                    # print(file)
+    def __init__(self, root: Union[str, Path]) -> None:
+        self.root = Path(root).expanduser().resolve()
+        if not self.root.exists():
+            raise FileNotFoundError(f"Dataset root does not exist: {self.root}")
+        if not self.root.is_dir():
+            raise NotADirectoryError(f"Dataset root is not a directory: {self.root}")
 
-                    # Image.open(path+file).show()
+        if self.root not in self._DATASET_CACHE:
+            self._DATASET_CACHE[self.root] = self._scan_dataset(self.root)
 
-                    # count += 1
-                    # if count > 1:
-                    #     break;
-                
-                # layers.append(layer) # TODO: determine if this will cause us to use too much memory
-                num_layers += 1
+        self.layers = self._DATASET_CACHE[self.root]
+        self.layer_ids = [layer.identifier for layer in self.layers]
+        self._layers_by_id = {layer.identifier: layer for layer in self.layers}
 
-                progress.set_description(f'Images: {num_images} | Path: "{path}" \t |')
+    def get_layer_count(self) -> int:
+        return len(self.layers)
 
-        print(f"Empty Layers: {num_empty}")
+    def get_layer_ids(self) -> List[int]:
+        return list(self.layer_ids)
+
+    def get_tile_count(self, layer_id: int) -> int:
+        return len(self._require_layer(layer_id).tiles)
+
+    def get_tile_counts(self) -> Dict[int, int]:
+        return {layer.identifier: len(layer.tiles) for layer in self.layers}
+
+    def load(
+        self,
+        layers: RangeSpec = None,
+        tiles: RangeSpec = None,
+        *,
+        load_images: bool = True,
+    ) -> Dict[int, List[ImageValue]]:
+        """Return a sequential layer->tiles dictionary.
+
+        `layers` may be:
+        - `None` to load every layer
+        - an `int` to load a single layer
+        - a `(start, end)` pair to load an inclusive range of layer IDs
+
+        `tiles` may be:
+        - `None` to load every tile from each requested layer
+        - an `int` to load a single tile index from each layer
+        - a `(start, end)` pair to load an inclusive range of tile indices
+        """
+
+        layer_ids = self._resolve_layer_ids(layers)
+        loaded: Dict[int, List[ImageValue]] = {}
+
+        for layer_id in layer_ids:
+            layer = self._require_layer(layer_id)
+            tile_indices = self._resolve_tile_indices(layer, tiles)
+            loaded[layer_id] = [self._load_tile(layer.tiles[index], load_images=load_images) for index in tile_indices]
+
+        return loaded
+
+    def load_paths(self, layers: RangeSpec = None, tiles: RangeSpec = None) -> Dict[int, List[Path]]:
+        return self.load(layers=layers, tiles=tiles, load_images=False)  # type: ignore[return-value]
+
+    def _require_layer(self, layer_id: int) -> LayerRecord:
+        try:
+            return self._layers_by_id[layer_id]
+        except KeyError as exc:
+            raise IndexError(f"Layer {layer_id} does not exist") from exc
+
+    def _resolve_layer_ids(self, layers: RangeSpec) -> List[int]:
+        if layers is None:
+            return list(self.layer_ids)
+
+        if isinstance(layers, int):
+            self._require_layer(layers)
+            return [layers]
+
+        start, end = self._parse_range(layers, "layers")
+        resolved = [layer_id for layer_id in self.layer_ids if start <= layer_id <= end]
+        expected = list(range(start, end + 1))
+        if resolved != expected:
+            missing = [layer_id for layer_id in expected if layer_id not in self._layers_by_id]
+            raise IndexError(f"Requested layer range contains missing layers: {missing}")
+        return resolved
+
+    def _resolve_tile_indices(self, layer: LayerRecord, tiles: RangeSpec) -> List[int]:
+        if tiles is None:
+            return list(range(len(layer.tiles)))
+
+        if isinstance(tiles, int):
+            self._validate_tile_index(layer, tiles)
+            return [tiles]
+
+        start, end = self._parse_range(tiles, "tiles")
+        for tile_index in range(start, end + 1):
+            self._validate_tile_index(layer, tile_index)
+        return list(range(start, end + 1))
+
+    @staticmethod
+    def _parse_range(value: Sequence[int], label: str) -> Tuple[int, int]:
+        if len(value) == 1:
+            start = int(value[0])
+            end = start
+        elif len(value) == 2:
+            start = int(value[0])
+            end = start if value[1] is None else int(value[1])
+        else:
+            raise ValueError(f"{label} must be an int, None, or a 1-item or 2-item range")
+        if start < 0 or end < 0:
+            raise IndexError(f"{label} indices must be non-negative")
+        if end < start:
+            raise ValueError(f"{label} range must be ordered as (start, end)")
+        return start, end
+
+    @staticmethod
+    def _validate_tile_index(layer: LayerRecord, tile_index: int) -> None:
+        if tile_index < 0 or tile_index >= len(layer.tiles):
+            raise IndexError(f"Tile {tile_index} does not exist in layer {layer.identifier}")
+
+    @staticmethod
+    def _load_tile(tile_path: Path, *, load_images: bool) -> ImageValue:
+        if not load_images:
+            return tile_path
+
+        if Image is None or np is None:
+            raise RuntimeError("Pillow and numpy are required to load images into memory")
+
+        with Image.open(tile_path) as image:
+            return np.asarray(image)
+
+    @classmethod
+    def _scan_dataset(cls, root: Path) -> Tuple[LayerRecord, ...]:
+        layer_dirs = [entry for entry in root.iterdir() if entry.is_dir()]
+        records: List[LayerRecord] = []
+
+        for fallback_id, layer_dir in enumerate(sorted(layer_dirs, key=lambda item: cls._natural_sort_key(item.name))):
+            image_files = tuple(sorted(cls._iter_image_files(layer_dir), key=lambda item: cls._natural_sort_key(str(item.relative_to(layer_dir)))))
+            if not image_files:
+                continue
+            records.append(
+                LayerRecord(
+                    identifier=cls._extract_identifier(layer_dir.name, fallback_id),
+                    path=layer_dir,
+                    tiles=image_files,
+                )
+            )
+
+        if records:
+            identifiers = [record.identifier for record in records]
+            if len(set(identifiers)) != len(identifiers):
+                raise ValueError(f"Layer identifiers must be unique, found duplicates in dataset root: {root}")
+            return tuple(sorted(records, key=lambda layer: layer.identifier))
+
+        root_images = tuple(sorted(cls._iter_image_files(root), key=lambda item: cls._natural_sort_key(str(item.relative_to(root)))))
+        if root_images:
+            return (LayerRecord(identifier=0, path=root, tiles=root_images),)
+
+        raise FileNotFoundError(f"No image files were found under dataset root: {root}")
+
+    @classmethod
+    def _iter_image_files(cls, directory: Path) -> Iterable[Path]:
+        for path in directory.rglob("*"):
+            if path.is_file() and path.suffix.lower() in cls.IMAGE_SUFFIXES:
+                yield path
+
+    @staticmethod
+    def _extract_identifier(name: str, fallback: int) -> int:
+        match = re.search(r"\d+", name)
+        return int(match.group(0)) if match else fallback
+
+    @staticmethod
+    def _natural_sort_key(value: str) -> Tuple[Union[int, str], ...]:
+        parts = re.split(r"(\d+)", value.lower())
+        return tuple(int(part) if part.isdigit() else part for part in parts if part)

--- a/Sandbox/LoadNeuronData/DataLoader.py
+++ b/Sandbox/LoadNeuronData/DataLoader.py
@@ -30,7 +30,9 @@ class LayerRecord:
 
 
 class DataLoader:
-    """Load sequential FlyEM layers and tiles from a directory tree.
+
+    """
+    Load sequential FlyEM layers and tiles from a directory tree.
 
     The loader scans the dataset once per root path and caches the discovered
     layer/tile structure at the class level so repeated instances do not need
@@ -74,7 +76,8 @@ class DataLoader:
         *,
         load_images: bool = True,
     ) -> Dict[int, List[ImageValue]]:
-        """Return a sequential layer->tiles dictionary.
+        """
+        Return a sequential layer->tiles dictionary.
 
         `layers` may be:
         - `None` to load every layer

--- a/Sandbox/LoadNeuronData/DataLoader.py
+++ b/Sandbox/LoadNeuronData/DataLoader.py
@@ -30,7 +30,9 @@ class LayerRecord:
 
 
 class DataLoader:
-    """Load sequential FlyEM layers and tiles from a directory tree.
+
+    """
+    Load sequential FlyEM layers and tiles from a directory tree.
 
     The loader scans the dataset once per root path and caches the discovered
     layer/tile structure at the class level so repeated instances do not need
@@ -41,6 +43,7 @@ class DataLoader:
     _DATASET_CACHE: ClassVar[Dict[Path, Tuple[LayerRecord, ...]]] = {}
 
     def __init__(self, root: Union[str, Path]) -> None:
+        """Create a loader for a FlyEM layer/tile dataset root."""
         self.root = Path(root).expanduser().resolve()
         if not self.root.exists():
             raise FileNotFoundError(f"Dataset root does not exist: {self.root}")
@@ -73,7 +76,8 @@ class DataLoader:
         *,
         load_images: bool = True,
     ) -> Dict[int, List[ImageValue]]:
-        """Return a sequential layer->tiles dictionary.
+        """
+        Return a sequential layer->tiles dictionary.
 
         `layers` may be:
         - `None` to load every layer
@@ -85,7 +89,6 @@ class DataLoader:
         - an `int` to load a single tile index from each layer
         - a `(start, end)` pair to load an inclusive range of tile indices
         """
-
         layer_ids = self._resolve_layer_ids(layers)
         loaded: Dict[int, List[ImageValue]] = {}
 

--- a/Sandbox/LoadNeuronData/DataLoader.py
+++ b/Sandbox/LoadNeuronData/DataLoader.py
@@ -30,9 +30,7 @@ class LayerRecord:
 
 
 class DataLoader:
-
-    """
-    Load sequential FlyEM layers and tiles from a directory tree.
+    """Load sequential FlyEM layers and tiles from a directory tree.
 
     The loader scans the dataset once per root path and caches the discovered
     layer/tile structure at the class level so repeated instances do not need
@@ -76,8 +74,7 @@ class DataLoader:
         *,
         load_images: bool = True,
     ) -> Dict[int, List[ImageValue]]:
-        """
-        Return a sequential layer->tiles dictionary.
+        """Return a sequential layer->tiles dictionary.
 
         `layers` may be:
         - `None` to load every layer


### PR DESCRIPTION
Fixes #10.

This replaces the incomplete sandbox data loader with a usable FlyEM-oriented loader API.

Included in this patch:

- scans the dataset root once and caches discovered layers at the class level
- sorts layers and tiles in a stable natural order
- exposes layer-count, layer-id, and tile-count helpers
- supports loading a single layer, a layer range, a single tile, or a tile range
- raises clear exceptions for missing roots, missing layers, and out-of-range tile requests
- can either return loaded image arrays or just the resolved image paths

Verification:

- `PYTHONDONTWRITEBYTECODE=1 python3` import check for `Sandbox/LoadNeuronData/DataLoader.py`
- synthetic dataset check for natural layer/tile sorting, inclusive layer/tile range loading, path-only loading, and missing-layer-range errors


I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
