### PR TITLE
Remove stale model loader threading TODOs

### DIFF
--- a/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h
+++ b/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h
@@ -35,8 +35,6 @@
 
 
 // FIXME: Fix reloading of same textures
-// FIXME: Fix limitation of one thread
-// FIXME: Implement multithreaded image preloading?
 
 /**
  * @brief Class for loading models (fbx, gltx, etc.) based on the ASSIMP library
@@ -132,4 +130,3 @@ class STS_CLASS_ModelLoader {
 
 
 };
-


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove stale ModelLoader TODOs for single-thread limitation and multithreaded image preloading
- keep the still-actionable duplicate texture reload FIXME in place

## Verification
- git diff --check
- rg evidence check for WorkerThreads_ creation and std::async texture decoding
- git diff --binary origin/master -- Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h | git apply --check --cached --whitespace=error-all