### PR TITLE
Avoid duplicate model texture reloads

### DIFF
--- a/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.cpp
+++ b/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.cpp
@@ -275,8 +275,21 @@ void STS_CLASS_ModelLoader::LoadModel(long AssetID, std::shared_ptr<STS_OBJECT_M
         ModelID = Metadata["ModelID"].as<long>();
         YAML::Node TexturePathNode = Metadata["TextureIDs"];
         for (YAML::const_iterator it=TexturePathNode.begin(); it!=TexturePathNode.end(); ++it) {
-            TexturePaths.push_back(it->first.as<std::string>());
-            TextureIDs.push_back(it->second.as<long>());
+            std::string TexturePath = it->first.as<std::string>();
+            long TextureID = it->second.as<long>();
+
+            bool IsDuplicateTexture = false;
+            for (unsigned long i = 0; i < TexturePaths.size(); i++) {
+                if ((TexturePaths[i] == TexturePath) && (TextureIDs[i] == TextureID)) {
+                    IsDuplicateTexture = true;
+                    break;
+                }
+            }
+
+            if (!IsDuplicateTexture) {
+                TexturePaths.push_back(TexturePath);
+                TextureIDs.push_back(TextureID);
+            }
         }
     } catch(YAML::BadSubscript) {
         SystemUtils_->Logger_->Log(std::string(std::string("Error Loading Model '") + std::to_string(AssetID) + std::string("', Asset Metadata Corrupt")).c_str(), 9);
@@ -453,4 +466,3 @@ void STS_CLASS_ModelLoader::LoadMaterialTextures(std::vector<int>* IDs, std::vec
 
 
 }
-

--- a/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h
+++ b/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h
@@ -34,7 +34,6 @@
 #include <STS_STRUCT_SystemUtils.h>
 
 
-// FIXME: Fix reloading of same textures
 // FIXME: Fix limitation of one thread
 // FIXME: Implement multithreaded image preloading?
 
@@ -132,4 +131,3 @@ class STS_CLASS_ModelLoader {
 
 
 };
-


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- skip exact duplicate model texture metadata entries before starting texture decode futures
- preserve first-occurrence order and keep same-path/different-asset-id entries distinct
- remove the completed duplicate texture reload FIXME

## Verification
- git diff --check
- rg evidence check for duplicate detection and async texture decoding
- focused C++17 texture-dedupe probe preserving order and distinct IDs
- git diff --binary origin/master -- Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.h Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.cpp | git apply --check --cached --whitespace=error-all
- cmake -S . -B /tmp/brain-genix-sts-dedupe-build -DCMAKE_BUILD_TYPE=Debug (fails on bundled backward CMake minimum policy with current CMake)
- cmake -S . -B /tmp/brain-genix-sts-dedupe-build-policy -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5