### PR TITLE
Ensure STS worker counts are positive

### DIFF
--- a/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.cpp
+++ b/Source/Core/Loader/STS_ModelLoader/STS_CLASS_ModelLoader.cpp
@@ -22,10 +22,12 @@ STS_CLASS_ModelLoader::STS_CLASS_ModelLoader(std::shared_ptr<STS_STRUCT_SystemUt
     // Create Worker Threads
     if (MaxModelLoadingThreads == -1) {
         SystemUtils_->Logger_->Log("Identifying Number Of CPU Cores", 4);
-        MaxModelLoadingThreads = std::thread::hardware_concurrency();
-    SystemUtils_->Logger_->Log(std::string(std::string("Identified ") + std::to_string(MaxModelLoadingThreads) + std::string(" Cores")).c_str(), 4);
-
-        
+        unsigned int DetectedHardwareThreads = std::thread::hardware_concurrency();
+        MaxModelLoadingThreads = DetectedHardwareThreads == 0 ? 1 : (int)DetectedHardwareThreads;
+        SystemUtils_->Logger_->Log(std::string(std::string("Identified ") + std::to_string(MaxModelLoadingThreads) + std::string(" Cores")).c_str(), 4);
+    }
+    if (MaxModelLoadingThreads < 1) {
+        MaxModelLoadingThreads = 1;
     }
     SystemUtils_->Logger_->Log(std::string(std::string("Creating ") + std::to_string(MaxModelLoadingThreads) + std::string("Model Loading Threads")).c_str(), 4);
     for (int i = 0; i < MaxModelLoadingThreads; i++) {
@@ -453,4 +455,3 @@ void STS_CLASS_ModelLoader::LoadMaterialTextures(std::vector<int>* IDs, std::vec
 
 
 }
-

--- a/Source/Core/NeuronFeatureExtraction/STS_NeuronCapacitanceExtraction/STS_FUNCTION_GetNumCPUs.cpp
+++ b/Source/Core/NeuronFeatureExtraction/STS_NeuronCapacitanceExtraction/STS_FUNCTION_GetNumCPUs.cpp
@@ -9,7 +9,8 @@
 int STS_FUNCTION_GetNumberCPUs() {
 
     // Get Number
-    int NumCPUS = std::thread::hardware_concurrency();
+    unsigned int DetectedHardwareThreads = std::thread::hardware_concurrency();
+    int NumCPUS = DetectedHardwareThreads == 0 ? 1 : (int)DetectedHardwareThreads;
 
     // Return 
     return NumCPUS;


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- fall back to one model-loader worker when `std::thread::hardware_concurrency()` reports `0`
- clamp explicitly configured nonpositive STS model-loader worker counts to one worker
- make `STS_FUNCTION_GetNumberCPUs()` return at least one worker for downstream threading code

## Verification
- `git diff --check`
- focused C++17 worker-count probe for hardware-concurrency fallback and configured-count clamping
- source search confirming the model-loader and CPU-helper fallback paths
- clean patch apply against a temporary `origin/master` worktree
- `cmake -S . -B /tmp/sts-worker-fallback-cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
