### PR TITLE
Fix stitching plugin argument keys

### DIFF
--- a/Sandbox/Stitch/stitching.py
+++ b/Sandbox/Stitch/stitching.py
@@ -48,7 +48,7 @@ class Stitch:
             'type': '[Unknown position]',
             'order': '[All files in directory]',
             'directory': self.DataLocation,
-            'confirm_files'
+            'confirm_files': True,
             'output_textfile_name': 'TileConfiguration.txt',
             'fusion_method': '[Linear Blending]',
             'regression_threshold': '0.30',
@@ -96,7 +96,7 @@ class Stitch:
             'first_file_index_i': str(self.first_file_index_i),
             'directory': self.DataLocation,
             'file_names': str(self.file_names),
-            'confirm_files'
+            'confirm_files': True,
             'output_textfile_name': 'TileConfiguration.txt',
             'fusion_method': '[Linear Blending]',
             'regression_threshold': '0.30',


### PR DESCRIPTION
## Summary
- split the malformed stitched string keys in the ImageJ plugin argument dictionaries
- pass confirm_files explicitly so output_textfile_name is delivered as its own parameter

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile Sandbox/Stitch/stitching.py
- focused AST probe confirming both plugin arg dicts contain confirm_files and output_textfile_name, with no confirm_filesoutput_textfile_name key
- git diff --check
- clean patch apply against origin/master in a detached worktree