### PR TITLE
Guard triangle area demo loop

### DIFF
--- a/Sandbox/TriangleArea/TriangleArea.py
+++ b/Sandbox/TriangleArea/TriangleArea.py
@@ -80,6 +80,6 @@ def find_line_length(X1, Y1, Z1, X2, Y2, Z2):
 
     return Length
 
-
-for x in range(10000000):
-    find_triangle_area(A,B,C)
+if __name__ == "__main__":
+    for x in range(10000000):
+        find_triangle_area(A,B,C)


### PR DESCRIPTION
## Summary
- move the 10,000,000-iteration triangle-area demo loop under a __main__ guard
- keep find_triangle_area and find_line_length importable without triggering the benchmark loop

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile Sandbox/TriangleArea/TriangleArea.py
- import probe confirming the module loads quickly and the sample triangle area remains 15.0
- AST/source probe confirming no top-level loop remains and the demo is __main__ guarded
- git diff --check
- clean sparse patch apply against origin/master