### PR TITLE
Fix layer merge result path check

### DIFF
--- a/Sandbox/Stitch/layermerge.py
+++ b/Sandbox/Stitch/layermerge.py
@@ -60,10 +60,9 @@ class SliceMerge:
         #os.remove(os.path.join(ROOT_DIR, 'results.jpg'))
         self.StackToRGB(self.DataLocation)
         print("we moved past the function calling")
-        if os.path.exists("output/result.jpg"):
+        if os.path.exists(os.path.join(self.DataLocation, "result.jpg")):
             print("stack to rgb functionality verified")
         else:
             print(" stack to rgb functionality failed")
-
 
 


### PR DESCRIPTION
## Summary
- check for StackToRGB output under the configured SliceMerge data directory
- avoid reporting layer merge failure when callers use a non-default DataLocation or run from another working directory

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Testing
- python3 -m py_compile Sandbox/Stitch/layermerge.py
- import-stub behavior probe with fake ImageJ/scyjava modules confirming Test() verifies DataLocation/result.jpg
- rg -n "output/result\.jpg|result\.jpg" Sandbox/Stitch/layermerge.py
- git diff --check origin/master
- clean origin/master worktree patch apply with git apply --check --whitespace=error-all