### PR TITLE
Use RandomOrder output directory

### DIFF
--- a/Sandbox/Stitch/stitching.py
+++ b/Sandbox/Stitch/stitching.py
@@ -56,12 +56,14 @@ class Stitch:
             'absolute_displacement_threshold': '3.50',
             'computation_parameters': '[Save memory (but be slower)]',
             'image_output': '[Write to disk]',
-            'OutputDirectory': self.OutputDirectory
+            'output_directory': self.OutputDirectory
         }
         ij.py.run_plugin(plugin, args)
         #print("stitching complete in random order the results can be viewed at " + self.OutputDirectory)
+        OutputPath = os.path.join(ROOT_DIR, self.OutputDirectory)
+        os.makedirs(OutputPath, exist_ok=True)
         for i in range(1, 4):
-            shutil.move(os.path.join(ROOT_DIR, self.DataLocation + '/img_t1_z1_c' + str(i)), os.path.join(ROOT_DIR, 'output'))
+            shutil.move(os.path.join(ROOT_DIR, self.DataLocation + '/img_t1_z1_c' + str(i)), OutputPath)
 
         return
         """


### PR DESCRIPTION
Summary
- Pass RandomOrder stitching output through the ImageJ output_directory argument key.
- Create the requested output directory before moving reconstructed images.
- Move RandomOrder output images to the configured output directory instead of hard-coded ROOT_DIR/output.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile Sandbox/Stitch/stitching.py\n- Focused import-stub probe for fake ImageJ, os.makedirs, and shutil.move confirming custom output_directory and move destination usage.\n- git diff --check\n- Clean patch apply against fresh origin/master.\n- Three-way merge simulation after applying STS PR #30 completed without conflicts.